### PR TITLE
Update to fix broken export directory structure.

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -71,7 +71,7 @@ sleep 2
 
 if [ "$export" ]; then
   mkdir $export 2>/dev/null
-  format=$export/LinEnum-export-`date +"%d-%m-%y_%k:%M"`
+  format=$export/LinEnum-export-`date +"%d-%m-%y_%H:%M"`
   mkdir $format 2>/dev/null
 else 
   :


### PR DESCRIPTION
The use "%k" implies whitespace which breaks some systems.
