### PR TITLE
List writable files that dont belong to us

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -271,6 +271,17 @@ else
   :
 fi
 
+#looks for files we can write to that don't belong to us
+if [ "$thorough" = "1" ]; then
+  grfilesall=`find / -writable -not -user \`whoami\` -type f -not -path "/proc/*" -exec ls -al {} \; 2>/dev/null`
+  if [ "$grfilesall" ]; then
+    echo -e "\e[00;31mFiles not owned by user but writable by group:\e[00m\n$grfilesall" |tee -a $report 2>/dev/null
+    echo -e "\n" |tee -a $report 2>/dev/null
+  else
+    :
+  fi
+fi
+
 #looks for world-reabable files within /home - depending on number of /home dirs & files, this can take some time so is only 'activated' with thorough scanning switch
 if [ "$thorough" = "1" ]; then
 wrfileshm=`find /home/ -perm -4 -type f -exec ls -al {} \; 2>/dev/null`


### PR DESCRIPTION
In the past I've found it useful to see a list of files that aren't owned by the current user, but are writeable by a group that the current user belongs to. Its a list of not-obvious files the current user can write to.

Running some tests against a test box see's this command finish in ~8 seconds. I'm not sure what your threshold for putting a feature behind `thorough` mode is, so I'm playing it safe. Running LinEnum in thorough mode on my test box takes ~5 minutes, regular mode finishes in ~7 seconds.