### PR TITLE
Export location fix

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -71,7 +71,7 @@ sleep 2
 
 if [ "$export" ]; then
   mkdir $export 2>/dev/null
-  format=$export/LinEnum-export-`date +"%d-%m-%y_%k:%M"`
+  format=$export/LinEnum-export-`date +"%d-%m-%y_%H:%M"`
   mkdir $format 2>/dev/null
 else 
   :


### PR DESCRIPTION
Fix for issue #7 

The export location parameter (-e) was not working properly.
When defining a location, a folder was generated, but it was empty at the end of the program execution.
Instead the files were archived in a new folder in the LinEnum directory.