### PR TITLE
All the services

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -831,6 +831,37 @@ if [ "$usrrcdperms" ]; then
 else 
   :
 fi
+
+initread=`ls -la /etc/init/ 2>/dev/null`
+if [ "$initread" ]; then
+  echo -e "\e[00;31m[-] /etc/init/ config file permissions:\e[00m\n$initread"
+  echo -e "\n"
+else
+  :
+fi
+
+# upstart scripts not belonging to root
+initperms=`find /etc/init \! -uid 0 -type f 2>/dev/null |xargs -r ls -la 2>/dev/null`
+if [ "$initperms" ]; then
+   echo -e "\e[00;31m[-] /etc/init/ config files not belonging to root:\e[00m\n$initperms"
+else
+  :
+fi
+
+systemdread=`ls -lthR /etc/init/ 2>/dev/null`
+if [ "$systemdread" ]; then
+  echo -e "\e[00;31m[-] /lib/systemd/* config file permissions:\e[00m\n$systemdread"
+else
+  :
+fi
+
+# systemd files not belonging to root
+systemdperms=`find /lib/systemd/ \! -uid 0 -type f 2>/dev/null |xargs -r ls -la 2>/dev/null`
+if [ "$systemdperms" ]; then
+   echo -e "\e[00;31m[-] /lib/systemd/* config files not belonging to root:\e[00m\n$systemdperms"
+else
+  :
+fi
 }
 
 software_configs()

--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -848,7 +848,7 @@ else
   :
 fi
 
-systemdread=`ls -lthR /etc/init/ 2>/dev/null`
+systemdread=`ls -lthR /lib/systemd/ 2>/dev/null`
 if [ "$systemdread" ]; then
   echo -e "\e[00;31m[-] /lib/systemd/* config file permissions:\e[00m\n$systemdread"
 else


### PR DESCRIPTION
Since /etc/init.d/ is becoming a legacy way of adding services, putting /etc/init/ and /lib/systemd/ into the list of places to check.

A question as well - why check for files not owned by root rather than files that are writable by the current user?  It seems the latter would be more of a viable privesc check than the former; maybe I'm misunderstanding the purpose?