### PR TITLE
Added some POSIX capabilities checks 

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -1058,7 +1058,7 @@ intsuid=`find / -perm -4000 -type f -exec ls -la {} \; 2>/dev/null | grep -w $bi
 		echo -e "\n" 
 	else 
 		:
-	fi
+		fi
   else
 	:
 fi
@@ -1158,6 +1158,67 @@ fileswithcaps=`getcap -r / 2>/dev/null || /sbin/getcap -r / 2>/dev/null`
 	if [ "$fileswithcaps" ]; then
 		echo -e "\e[00;31m[+] Files with POSIX capabilities set:\e[00m\n$fileswithcaps"
 		echo -e "\n"
+	else
+		:
+	fi
+  else
+	  :
+fi
+
+if [ "$thorough" = "1" ]; then
+	if [ "$export" ] && [ "$fileswithcaps" ]; then
+		mkdir $format/files_with_capabilities/ 2>/dev/null
+		for i in $fileswithcaps; do cp $i $format/files_with_capabilities/; done 2>/dev/null
+	else 
+		:
+	fi
+  else
+	  :
+fi
+
+#searches /etc/security/capability.conf for users associated capapilies
+if [ "$thorough" = "1" ]; then
+userswithcaps=`grep -v '^#\|none\|^$' /etc/security/capability.conf 2>/dev/null`
+	if [ "$userswithcaps" ]; then
+		echo -e "\e[00;33m[+] Users with specific POSIX capabilities:\e[00m\n$userswithcaps"
+		echo -e "\n"
+	else
+		:
+	fi
+  else
+	  :
+fi
+
+if [ "$thorough" = "1" ] && [ "$userswithcaps" ] ; then
+#matches the capabilities found associated with users with the current user
+matchedcaps=`echo -e "$userswithcaps" | grep \`whoami\` | awk '{print $1}' 2>/dev/null`
+	if [ "$matchedcaps" ]; then
+		echo -e "\e[00;33m[+] Capabilities associated with the current user:\e[00m\n$matchedcaps"
+		echo -e "\n"
+		#matches the files with capapbilities with capabilities associated with the current user
+		matchedfiles=`echo -e "$matchedcaps" | while read -r cap ; do echo -e "$fileswithcaps" | grep "$cap" ; done 2>/dev/null`
+		if [ "$matchedfiles" ]; then
+			echo -e "\e[00;33m[+] Files with the same capabilities associated with the current user (You may want to try abusing those capabilties):\e[00m\n$matchedfiles"
+			echo -e "\n"
+			#lists the permissions of the files having the same capabilies associated with the current user
+			matchedfilesperms=`echo -e "$matchedfiles" | awk '{print $1}' | while read -r f; do ls -la $f ;done 2>/dev/null`
+			echo -e "\e[00;33m[+] Permissions of files with the same capabilities associated with the current user:\e[00m\n$matchedfilesperms"
+			echo -e "\n"
+			if [ "$matchedfilesperms" ]; then
+				#checks if any of the files with same capabilities associated with the current user is writable
+				writablematchedfiles=`echo -e "$matchedfiles" | awk '{print $1}' | while read -r f; do find $f -writable -exec ls -la {} + ;done 2>/dev/null`
+				if [ "$writablematchedfiles" ]; then
+					echo -e "\e[00;33m[+] User/Group writable files with the same capabilities associated with the current user:\e[00m\n$writablematchedfiles"
+					echo -e "\n"
+				else
+					:
+				fi
+			else
+				:
+			fi
+		else
+			:
+		fi
 	else
 		:
 	fi

--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -1152,6 +1152,19 @@ wwguidrt=`find / -uid 0 -perm -2007 -type f -exec ls -la {} 2>/dev/null \;`
 	:
 fi
 
+#list all files with POSIX capabilities set along with there capabilities
+if [ "$thorough" = "1" ]; then
+fileswithcaps=`getcap -r / 2>/dev/null || /sbin/getcap -r / 2>/dev/null`
+	if [ "$fileswithcaps" ]; then
+		echo -e "\e[00;31m[+] Files with POSIX capabilities set:\e[00m\n$fileswithcaps"
+		echo -e "\n"
+	else
+		:
+	fi
+  else
+	  :
+fi
+
 #list all world-writable files excluding /proc and /sys
 if [ "$thorough" = "1" ]; then
 wwfiles=`find / ! -path "*/proc/*" ! -path "/sys/*" -perm -2 -type f -exec ls -la {} 2>/dev/null \;`

--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -1058,7 +1058,7 @@ intsuid=`find / -perm -4000 -type f -exec ls -la {} \; 2>/dev/null | grep -w $bi
 		echo -e "\n" 
 	else 
 		:
-		fi
+	fi
   else
 	:
 fi

--- a/README.md
+++ b/README.md
@@ -97,3 +97,4 @@ High-level summary of the checks/tasks performed by LinEnum:
 * Platform/software specific tests:
   * Checks to determine if we're in a Docker container
   * Checks to see if the host has Docker installed
+  * Checks to determine if we're in an LXC container

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ High-level summary of the checks/tasks performed by LinEnum:
   * Locate all world-writable SUID/GUID files
   * Locate all SUID/GUID files owned by root
   * Locate ‘interesting’ SUID/GUID files (i.e. nmap, vim etc)
+  * Locate files with POSIX capabilities
   * List all world-writable files
   * Find/list all accessible *.plan files and display contents
   * Find/list all accessible *.rhosts files and display contents


### PR DESCRIPTION
Inspired by a CTF challenge I've recently went through, I've decided to add some checks that scan the system for files with POSIX capabilities (Linux capabilities) set, furthermore, the code also searches for users who have specific capabilities associated with them, and checks if the current user has any associated capabilities and whether they have write permissions on the files that have the same capabilities.

Use case:

<img width="790" alt="capa" src="https://user-images.githubusercontent.com/21090640/44107396-cbd23708-a029-11e8-81f7-049a9f19ddb1.PNG">

