### PR TITLE
Add check for systemd timers

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -586,6 +586,24 @@ else
   :
 fi
 
+# list systemd timers
+if [ "$thorough" = "1" ]; then
+  # include inactive timers in thorough mode
+  systemdtimers="$(systemctl list-timers --all 2>/dev/null)"
+  info=""
+else
+  systemdtimers="$(systemctl list-timers 2>/dev/null |head -n -1 2>/dev/null)"
+  # replace the info in the output with a hint towards thorough mode
+  info="\e[2mEnable thorough tests to see inactive timers\e[00m"
+fi
+if [ "$systemdtimers" ]; then
+  echo -e "\e[00;31m[-] Systemd timers:\e[00m\n$systemdtimers\n$info"
+  echo -e "\n"
+else
+  :
+fi
+
+
 }
 networking_info()
 {

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ High-level summary of the checks/tasks performed by LinEnum:
   * List all cron jobs
   * Locate all world-writable cron jobs
   * Locate cron jobs owned by other users of the system
+  * List the active and inactive systemd timers
 * Services:
   * List network connections (TCP & UDP)
   * List running processes


### PR DESCRIPTION
This pull request adds support for listing systemd timers. These basically work similar to cron jobs which is why I included this check right after them. In my opinion, if cron jobs are enumerated, systemd timers should be as well.

There is an option to also view inactive timers which probably only decreases the signal to noise ratio so I only enabled this flag in thorough mode. If it's not set `systemctl` hints at it (`--all`), which is useless for the LinEnum user so I hinted at the thorough mode instead.