### PR TITLE
Fix TCP/UDP listening socket output

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -538,26 +538,26 @@ if [ ! "$defroute" ] && [ "$defrouteip" ]; then
 fi
 
 #listening TCP
-tcpservs=`netstat -antp 2>/dev/null`
+tcpservs=`netstat -ntpl 2>/dev/null`
 if [ "$tcpservs" ]; then
   echo -e "\e[00;31m[-] Listening TCP:\e[00m\n$tcpservs" 
   echo -e "\n"
 fi
 
-tcpservsip=`ss -t 2>/dev/null`
+tcpservsip=`ss -t -l -n 2>/dev/null`
 if [ ! "$tcpservs" ] && [ "$tcpservsip" ]; then
   echo -e "\e[00;31m[-] Listening TCP:\e[00m\n$tcpservsip" 
   echo -e "\n"
 fi
 
 #listening UDP
-udpservs=`netstat -anup 2>/dev/null`
+udpservs=`netstat -nupl 2>/dev/null`
 if [ "$udpservs" ]; then
   echo -e "\e[00;31m[-] Listening UDP:\e[00m\n$udpservs" 
   echo -e "\n"
 fi
 
-udpservsip=`ip -u 2>/dev/null`
+udpservsip=`ss -u -l -n 2>/dev/null`
 if [ ! "$udpservs" ] && [ "$udpservsip" ]; then
   echo -e "\e[00;31m[-] Listening UDP:\e[00m\n$udpservsip" 
   echo -e "\n"


### PR DESCRIPTION
Actual output for "Listening TCP":
```
[-] Listening TCP:
Active Internet connections (servers and established)     
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 127.0.0.1:5432          0.0.0.0:*               LISTEN      888/postgres
tcp        0      0 127.0.0.1:5433          0.0.0.0:*               LISTEN      887/postgres
tcp        0      0 192.168.1.x:48342       172.217.23.x:443        ESTABLISHED 2513/firefox-esr
tcp        0      0 192.168.1.x:40822       151.101.1.x:443         ESTABLISHED 2513/firefox-esr
```
Fix remove established and closed connections using -l (listen) param instead of -a (all).