### PR TITLE
List permissions on PATH directories to see if they are writable

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -375,7 +375,7 @@ fi
 #current path configuration
 pathinfo=`echo $PATH 2>/dev/null`
 if [ "$pathinfo" ]; then
-  pathswriteable=ls -ld `echo $PATH | tr ":" " "`
+  pathswriteable=`ls -ld $(echo $PATH | tr ":" " ")`
   echo -e "\e[00;31m[-] Path information:\e[00m\n$pathinfo" 
   echo -e "$pathswriteable"
   echo -e "\n"

--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -375,7 +375,9 @@ fi
 #current path configuration
 pathinfo=`echo $PATH 2>/dev/null`
 if [ "$pathinfo" ]; then
+  pathswriteable=ls -ld `echo $PATH | tr ":" " "`
   echo -e "\e[00;31m[-] Path information:\e[00m\n$pathinfo" 
+  echo -e "$pathswriteable"
   echo -e "\n"
 fi
 


### PR DESCRIPTION
Previously the PATH variable was only listed, but I think it makes sense to print the permissions on each directory in the PATH so that we can see if it is writable. 

This uses ls, tr and echo, but I'm sure it could be achieved with other tools if preferred.

Example output:

```
[-] Path information:
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
lrwxrwxrwx 1 root root      7 Aug 21  2018 /bin -> usr/bin
lrwxrwxrwx 1 root root      8 Aug 21  2018 /sbin -> usr/sbin
drwxr-xr-x 2 root root 135168 Sep  4 17:58 /usr/bin
drwxr-xr-x 3 root root   4096 Aug 16 13:40 /usr/local/bin
drwxr-xr-x 2 root root   4096 Jul 31  2018 /usr/local/sbin
drwxr-xr-x 2 root root  32768 Aug 11 23:08 /usr/sbin
```