### PR TITLE
Prevent finding false positive keys in self

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -940,7 +940,7 @@ fi
 
 #look for private keys - thanks djhohnstein
 if [ "$thorough" = "1" ]; then
-privatekeyfiles=`grep -rl "PRIVATE KEY-----" /home 2>/dev/null`
+privatekeyfiles=`grep -rl "[P]RIVATE KEY-----" /home 2>/dev/null`
 	if [ "$privatekeyfiles" ]; then
   		echo -e "\e[00;33m[+] Private SSH keys found!:\e[00m\n$privatekeyfiles"
   		echo -e "\n"
@@ -949,7 +949,7 @@ fi
 
 #look for AWS keys - thanks djhohnstein
 if [ "$thorough" = "1" ]; then
-awskeyfiles=`grep -rli "aws_secret_access_key" /home 2>/dev/null`
+awskeyfiles=`grep -rli "[a]ws_secret_access_key" /home 2>/dev/null`
 	if [ "$awskeyfiles" ]; then
   		echo -e "\e[00;33m[+] AWS secret keys found!:\e[00m\n$awskeyfiles"
   		echo -e "\n"


### PR DESCRIPTION
The script will flag itself as having private keys/AWS secret keys because the search strings match themselves. If one of the characters in the search string is wrapped in square brackets it will still find the same strings, but will no longer match itself.