### PR TITLE
software_configs(): improved the method of verifying apache2, mysql, psql before attempting checks

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -710,101 +710,86 @@ if [ "$sudover" ]; then
   echo -e "\n"
 fi
 
-#mysql details - if installed
-mysqlver=`mysql --version 2>/dev/null`
-if [ "$mysqlver" ]; then
-  echo -e "\e[00;31m[-] MYSQL version:\e[00m\n$mysqlver" 
-  echo -e "\n"
-fi
+command -v mysql && {
+	#mysql details - if installed
+	mysqlver=`mysql --version 2>/dev/null`
+	echo -e "\e[00;31m[-] MYSQL version:\e[00m\n$mysqlver" 
+	echo -e "\n"
 
-#checks to see if root/root will get us a connection
-mysqlconnect=`mysqladmin -uroot -proot version 2>/dev/null`
-if [ "$mysqlconnect" ]; then
-  echo -e "\e[00;33m[+] We can connect to the local MYSQL service with default root/root credentials!\e[00m\n$mysqlconnect" 
-  echo -e "\n"
-fi
+	#checks to see if root/root will get us a connection
+	mysqlconnect=`mysqladmin -uroot -proot version 2>/dev/null`
+	echo -e "\e[00;33m[+] We can connect to the local MYSQL service with default root/root credentials!\e[00m\n$mysqlconnect" 
+	echo -e "\n"
 
-#mysql version details
-mysqlconnectnopass=`mysqladmin -uroot version 2>/dev/null`
-if [ "$mysqlconnectnopass" ]; then
-  echo -e "\e[00;33m[+] We can connect to the local MYSQL service as 'root' and without a password!\e[00m\n$mysqlconnectnopass" 
-  echo -e "\n"
-fi
+	#mysql version details
+	mysqlconnectnopass=`mysqladmin -uroot version 2>/dev/null`
+	echo -e "\e[00;33m[+] We can connect to the local MYSQL service as 'root' and without a password!\e[00m\n$mysqlconnectnopass" 
+	echo -e "\n"
+}
 
-#postgres details - if installed
-postgver=`psql -V 2>/dev/null`
-if [ "$postgver" ]; then
-  echo -e "\e[00;31m[-] Postgres version:\e[00m\n$postgver" 
-  echo -e "\n"
-fi
+command -v psql && {
+	#postgres details - if installed
+	postgver=`psql -V 2>/dev/null`
+	echo -e "\e[00;31m[-] Postgres version:\e[00m\n$postgver" 
+	echo -e "\n"
 
-#checks to see if any postgres password exists and connects to DB 'template0' - following commands are a variant on this
-postcon1=`psql -U postgres -w template0 -c 'select version()' 2>/dev/null | grep version`
-if [ "$postcon1" ]; then
-  echo -e "\e[00;33m[+] We can connect to Postgres DB 'template0' as user 'postgres' with no password!:\e[00m\n$postcon1" 
-  echo -e "\n"
-fi
+	#checks to see if any postgres password exists and connects to DB 'template0' - following commands are a variant on this
+	postcon1=`psql -U postgres -w template0 -c 'select version()' 2>/dev/null | grep version`
+	echo -e "\e[00;33m[+] We can connect to Postgres DB 'template0' as user 'postgres' with no password!:\e[00m\n$postcon1" 
+	echo -e "\n"
 
-postcon11=`psql -U postgres -w template1 -c 'select version()' 2>/dev/null | grep version`
-if [ "$postcon11" ]; then
-  echo -e "\e[00;33m[+] We can connect to Postgres DB 'template1' as user 'postgres' with no password!:\e[00m\n$postcon11" 
-  echo -e "\n"
-fi
+	postcon11=`psql -U postgres -w template1 -c 'select version()' 2>/dev/null | grep version`
+	 echo -e "\e[00;33m[+] We can connect to Postgres DB 'template1' as user 'postgres' with no password!:\e[00m\n$postcon11" 
+	 echo -e "\n"
 
-postcon2=`psql -U pgsql -w template0 -c 'select version()' 2>/dev/null | grep version`
-if [ "$postcon2" ]; then
-  echo -e "\e[00;33m[+] We can connect to Postgres DB 'template0' as user 'psql' with no password!:\e[00m\n$postcon2" 
-  echo -e "\n"
-fi
+	postcon2=`psql -U pgsql -w template0 -c 'select version()' 2>/dev/null | grep version`
+	echo -e "\e[00;33m[+] We can connect to Postgres DB 'template0' as user 'psql' with no password!:\e[00m\n$postcon2" 
+	echo -e "\n"
 
-postcon22=`psql -U pgsql -w template1 -c 'select version()' 2>/dev/null | grep version`
-if [ "$postcon22" ]; then
-  echo -e "\e[00;33m[+] We can connect to Postgres DB 'template1' as user 'psql' with no password!:\e[00m\n$postcon22" 
-  echo -e "\n"
-fi
+	postcon22=`psql -U pgsql -w template1 -c 'select version()' 2>/dev/null | grep version`
+	echo -e "\e[00;33m[+] We can connect to Postgres DB 'template1' as user 'psql' with no password!:\e[00m\n$postcon22" 
+	echo -e "\n"
+}
 
-#apache details - if installed
-apachever=`apache2 -v 2>/dev/null; httpd -v 2>/dev/null`
-if [ "$apachever" ]; then
-  echo -e "\e[00;31m[-] Apache version:\e[00m\n$apachever" 
-  echo -e "\n"
-fi
+command -v apache2 && {
+	#apache details - if installed
+	apachever=`apache2 -v 2>/dev/null; httpd -v 2>/dev/null`
+	  echo -e "\e[00;31m[-] Apache version:\e[00m\n$apachever" 
+	  echo -e "\n"
 
-#what account is apache running under
-apacheusr=`grep -i 'user\|group' /etc/apache2/envvars 2>/dev/null |awk '{sub(/.*\export /,"")}1' 2>/dev/null`
-if [ "$apacheusr" ]; then
-  echo -e "\e[00;31m[-] Apache user configuration:\e[00m\n$apacheusr" 
-  echo -e "\n"
-fi
+	#what account is apache running under
+	apacheusr=`grep -i 'user\|group' /etc/apache2/envvars 2>/dev/null |awk '{sub(/.*\export /,"")}1' 2>/dev/null`
+	  echo -e "\e[00;31m[-] Apache user configuration:\e[00m\n$apacheusr" 
+	  echo -e "\n"
 
-if [ "$export" ] && [ "$apacheusr" ]; then
-  mkdir --parents $format/etc-export/apache2/ 2>/dev/null
-  cp /etc/apache2/envvars $format/etc-export/apache2/envvars 2>/dev/null
-fi
+	if [ "$export" ] && [ "$apacheusr" ]; then
+	  mkdir --parents $format/etc-export/apache2/ 2>/dev/null
+	  cp /etc/apache2/envvars $format/etc-export/apache2/envvars 2>/dev/null
+	fi
 
-#installed apache modules
-apachemodules=`apache2ctl -M 2>/dev/null; httpd -M 2>/dev/null`
-if [ "$apachemodules" ]; then
-  echo -e "\e[00;31m[-] Installed Apache modules:\e[00m\n$apachemodules" 
-  echo -e "\n"
-fi
+	#installed apache modules
+	apachemodules=`apache2ctl -M 2>/dev/null; httpd -M 2>/dev/null`
+	if [ "$apachemodules" ]; then
+	  echo -e "\e[00;31m[-] Installed Apache modules:\e[00m\n$apachemodules" 
+	  echo -e "\n"
+	fi
 
-#htpasswd check
-htpasswd=`find / -name .htpasswd -print -exec cat {} \; 2>/dev/null`
-if [ "$htpasswd" ]; then
-    echo -e "\e[00;33m[-] htpasswd found - could contain passwords:\e[00m\n$htpasswd"
-    echo -e "\n"
-fi
+	#htpasswd check
+	htpasswd=`find / -name .htpasswd -print -exec cat {} \; 2>/dev/null`
+	if [ "$htpasswd" ]; then
+	    echo -e "\e[00;33m[-] htpasswd found - could contain passwords:\e[00m\n$htpasswd"
+	    echo -e "\n"
+	fi
 
-#anything in the default http home dirs (a thorough only check as output can be large)
-if [ "$thorough" = "1" ]; then
-  apachehomedirs=`ls -alhR /var/www/ 2>/dev/null; ls -alhR /srv/www/htdocs/ 2>/dev/null; ls -alhR /usr/local/www/apache2/data/ 2>/dev/null; ls -alhR /opt/lampp/htdocs/ 2>/dev/null`
-  if [ "$apachehomedirs" ]; then
-    echo -e "\e[00;31m[-] www home dir contents:\e[00m\n$apachehomedirs" 
-    echo -e "\n"
-  fi
-fi
-
+	#anything in the default http home dirs (a thorough only check as output can be large)
+	if [ "$thorough" = "1" ]; then
+	  apachehomedirs=`ls -alhR /var/www/ 2>/dev/null; ls -alhR /srv/www/htdocs/ 2>/dev/null; ls -alhR /usr/local/www/apache2/data/ 2>/dev/null; ls -alhR /opt/lampp/htdocs/ 2>/dev/null`
+	  if [ "$apachehomedirs" ]; then
+	    echo -e "\e[00;31m[-] www home dir contents:\e[00m\n$apachehomedirs" 
+	    echo -e "\n"
+	  fi
+	fi
+}
 }
 
 interesting_files()


### PR DESCRIPTION
improved the method of verifying the binaries with `command -v`.   
Before the change, the apache section of checks was hanging unnecessarily long on some systems that took longer to return error if not present.   
I also applied the same to the mysql and psql checks.

- if apache does not exist, then no need to run apache checks
- If mysql does not exist, then  no need to run mysql checks
- if psql does not exist, then no need to run psql checks