### PR TITLE
add reference for priv esc when user is member of lxd group

### DIFF
--- a/LinEnum.sh
+++ b/LinEnum.sh
@@ -1309,7 +1309,8 @@ fi
 #specific checks - are we a member of the lxd group
 lxdgroup=`id | grep -i lxd 2>/dev/null`
 if [ "$lxdgroup" ]; then
-  echo -e "\e[00;33m[+] We're a member of the (lxd) group - could possibly misuse these rights!\e[00m\n$lxdgroup"
+  echo -e "\e[00;33m[+] We're a member of the (lxd) group - could possibly misusse these rights!"
+  echo -e "\e[00;33See: https://book.hacktricks.xyz/linux-unix/privilege-escalation/lxd-privilege-escalation\e[00m\n$lxdgroup"
   echo -e "\n"
 fi
 }


### PR DESCRIPTION
Right now the script just tells you that you are a member of the lxd group without giving any reference for priv esc. 